### PR TITLE
Making name of method to add on User model consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Install with composer...  `composer require mikemclin/passport-custom-request-gr
 ## Setup
 
 * Add `MikeMcLin\Passport\CustomRequestGrantProvider` to your list of providers **after** `Laravel\Passport\PassportServiceProvider`.
-* Add `getUserEntityByRequest($request)` method to your `User` model (or whatever model you have configured to work with Passport).
+* Add `byPassportCustomRequest($request)` method to your `User` model (or whatever model you have configured to work with Passport).
     * The method should accept an `Illuminate\Http\Request` object.
     * You should authorize and retrieve user based on this request
     * If you find that the request met your requirement, return the User model.
@@ -15,7 +15,7 @@ Install with composer...  `composer require mikemclin/passport-custom-request-gr
 
 * Make a **POST** request to `https://your-site.com/oauth/token`, just like you would a **Password** or **Refresh** grant.
 * The POST body should contain `grant_type` = `custom_request`.
-* The request will get routed to your `User::getUserEntityByRequest()` function, where you will determine if access should be granted or not.
+* The request will get routed to your `User::byPassportCustomRequest()` function, where you will determine if access should be granted or not.
 * An `access_token` and `refresh_token` will be returned if successful.
 
 ### Example


### PR DESCRIPTION
Previously in the README the method to add on the User model was noted as `User::getUserEntityByRequest()` in the setup/how to use section, however the example and package source has the method as `User::byPassportCustomRequest()`. This pull request updates the method names to be consistent with the package source code.
